### PR TITLE
fix: new menu May

### DIFF
--- a/src/pages/menu.astro
+++ b/src/pages/menu.astro
@@ -6,8 +6,7 @@ import Layout from "@/layouts/Layout.astro";
 
 const menuUrl =
   // "https://tolbertscms.com/wp-content/uploads/2024/11/TolbertsNewMenu090424.pdf";
-  "https://tolbertscms.com/wp-content/uploads/2026/01/TolbertsNewMenu010526-FINAL.pdf";
-// this is holiday menu
+  "https://tolbertscms.com/wp-content/uploads/2026/05/TolbertsNewMenu051326.pdf";
 
 async function checkResource(url) {
   try {


### PR DESCRIPTION
## Summary
- Bump hardcoded menu PDF URL in `src/pages/menu.astro` to May 13 version (`TolbertsNewMenu051326.pdf`)
- Drop stale holiday-menu comment

## Test plan
- [ ] Visit `/menu` on preview — confirms redirect to new PDF
- [ ] HEAD check passes against new URL