### PR TITLE
chore(docs): update README and package.json name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,48 @@
-# Astro Starter Kit: Basics
+# Tolbert's Restaurant & Chili Parlor
 
-```sh
-npm create astro@latest -- --template basics
-```
+Astro-powered website for Tolbert's Restaurant in historic downtown Grapevine, TX.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
+## Stack
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+- Astro 5.x (SSG + SSR)
+- React 18 (interactive components)
+- Tailwind CSS
+- Netlify
 
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
+## Pages
 
-## 🚀 Project Structure
+| Route            | Description                     |
+| ---------------- | ------------------------------- |
+| `/`              | Homepage                        |
+| `/about`         | Restaurant history & info       |
+| `/calendar`      | Live music & events calendar    |
+| `/menu`          | Dinner menu                     |
+| `/brunch-menu`   | Brunch menu                     |
+| `/posts`         | Blog / news                     |
 
-Inside of your Astro project, you'll see the following folders and files:
+## Development
+
+| Command           | Action                                       |
+| :---------------- | :------------------------------------------- |
+| `npm install`     | Installs dependencies                        |
+| `npm run dev`     | Starts local dev server at `localhost:4321`  |
+| `npm run build`   | Build your production site to `./dist/`      |
+| `npm run preview` | Preview your build locally, before deploying |
+
+## Configuration
+
+Feature flags live in `src/lib/config.ts`:
+
+- `showAnnouncement` — toggle site-wide announcement banner/card
+- `isUnderMaintenance` — show maintenance page instead of homepage
+
+## Project Structure
 
 ```text
-/
-├── public/
-│   └── favicon.svg
-├── src/
-│   ├── components/
-│   │   └── Card.astro
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
+src/
+  components/     # Astro + React components
+  content/posts/  # Markdown blog posts
+  layouts/        # Page layouts
+  lib/            # Utilities, API clients, config
+  pages/          # Route files
 ```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "andrew-riefenstahl-personal",
+  "name": "tolberts-astro",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
## Summary

Replaces the generic Astro starter README with project-specific documentation and fixes the package name.

## Changes

- **package.json:** Renamed `name` from `andrew-riefenstahl-personal` → `tolberts-astro`
- **README.md:** Rewrote with:
  - Project description and stack
  - Page routes table
  - Development commands
  - Configuration flags reference
  - Project structure overview

## Checklist

- [x] No sensitive info (API URLs, credentials, env vars)
- [x] Text-only, no screenshots
- [x] Generic and safe for public repo